### PR TITLE
[CP 291][Build] update helm lint command for helm v4 binary (#291)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -549,7 +549,7 @@ helm-k8s: helmify manifests kustomize clean-helm-k8s gen-kmm-charts-k8s
 	cp $(shell pwd)/hack/k8s-patch/k8s-kmm-patch/template-patch/*.yaml $(shell pwd)/helm-charts-k8s/charts/kmm/templates/
 	# patch multus
 	cp -r $(shell pwd)/hack/multus $(shell pwd)/helm-charts-k8s/charts/multus
-	cd $(shell pwd)/helm-charts-k8s; helm dependency update; helm lint; cd ..;
+	cd $(shell pwd)/helm-charts-k8s; helm dependency update; helm lint .; cd ..;
 	mkdir $(shell pwd)/helm-charts-k8s/crds
 	echo "moving crd yaml files to crds folder"
 	@for file in $(CRD_YAML_FILES); do \
@@ -558,7 +558,7 @@ helm-k8s: helmify manifests kustomize clean-helm-k8s gen-kmm-charts-k8s
 	rm $(shell pwd)/helm-charts-k8s/templates/*crd.yaml
 	$(MAKE) helm-docs
 	echo "dependency update, lint and pack charts"
-	cd $(shell pwd)/helm-charts-k8s; helm dependency update; helm lint; cd ..; helm package helm-charts-k8s/ --destination ./helm-charts-k8s
+	cd $(shell pwd)/helm-charts-k8s; helm dependency update; helm lint .; cd ..; helm package helm-charts-k8s/ --destination ./helm-charts-k8s
 	mv $(shell pwd)/helm-charts-k8s/network-operator-charts-$(HELM_CHARTS_VERSION).tgz $(shell pwd)/helm-charts-k8s/network-operator-helm-k8s-$(HELM_CHARTS_VERSION).tgz
 
 .PHONY: helm-openshift
@@ -578,7 +578,7 @@ helm-openshift: helmify manifests kustomize clean-helm-openshift gen-nfd-charts-
 	rm $(shell pwd)/helm-charts-openshift/charts/kmm/templates/device-plugin-rbac.yaml
 	# opeartor already has module-loader rbac yaml, removing the redundant rbac yaml from subchart
 	rm $(shell pwd)/helm-charts-openshift/charts/kmm/templates/module-loader-rbac.yaml
-	cd $(shell pwd)/helm-charts-openshift; helm dependency update; helm lint; cd ..;
+	cd $(shell pwd)/helm-charts-openshift; helm dependency update; helm lint .; cd ..;
 	mkdir $(shell pwd)/helm-charts-openshift/crds
 	echo "moving crd yaml files to crds folder"
 	@for file in $(CRD_YAML_FILES); do \
@@ -586,7 +586,7 @@ helm-openshift: helmify manifests kustomize clean-helm-openshift gen-nfd-charts-
 	done
 	rm $(shell pwd)/helm-charts-openshift/templates/*crd.yaml
 	echo "dependency update, lint and pack charts"
-	cd $(shell pwd)/helm-charts-openshift; helm dependency update; helm lint; cd ..; helm package helm-charts-openshift/ --destination ./helm-charts-openshift
+	cd $(shell pwd)/helm-charts-openshift; helm dependency update; helm lint .; cd ..; helm package helm-charts-openshift/ --destination ./helm-charts-openshift
 	mv $(shell pwd)/helm-charts-openshift/network-operator-charts-$(HELM_CHARTS_VERSION).tgz $(shell pwd)/helm-charts-openshift/network-operator-helm-openshift-$(HELM_CHARTS_VERSION).tgz
 
 .PHONY: helm-install


### PR DESCRIPTION
helm v3 supports both `helm lint` (current path) and `helm lint .`
helm v4 only supports `helm lint .`

Update the Makefile to make it work for both versions.