### PR TITLE
[CP 297] Add CNI plugins service account and values for K8s Helm chart (#297)

### DIFF
--- a/hack/k8s-patch/metadata-patch/values.yaml
+++ b/hack/k8s-patch/metadata-patch/values.yaml
@@ -129,6 +129,9 @@ configManager:
 utilsContainer:
   serviceAccount:
     annotations: {}
+cniPlugins:
+  serviceAccount:
+    annotations: {}
 global:
   proxy:
     env: {}

--- a/hack/k8s-patch/template-patch/serviceaccount.yaml
+++ b/hack/k8s-patch/template-patch/serviceaccount.yaml
@@ -96,3 +96,14 @@ metadata:
   {{- include "helm-charts-k8s.labels" . | nindent 4 }}
   annotations:
     {{- toYaml .Values.utilsContainer.serviceAccount.annotations | nindent 4 }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: amd-network-operator-cni-plugins
+  labels:
+    app.kubernetes.io/component: amd-nic
+    app.kubernetes.io/part-of: amd-nic
+  {{- include "helm-charts-k8s.labels" . | nindent 4 }}
+  annotations:
+    {{- toYaml .Values.cniPlugins.serviceAccount.annotations | nindent 4 }}

--- a/helm-charts-k8s/Chart.lock
+++ b/helm-charts-k8s/Chart.lock
@@ -9,4 +9,4 @@ dependencies:
   repository: file://./charts/multus
   version: 1.0.0
 digest: sha256:04b5697c8fd25d5cb6cac27cf0248a255fd8a31e9cd3c9b7b8f114eedf788eab
-generated: "2026-01-23T23:58:28.730788736Z"
+generated: "2026-04-15T19:11:06.215718963Z"

--- a/helm-charts-k8s/templates/serviceaccount.yaml
+++ b/helm-charts-k8s/templates/serviceaccount.yaml
@@ -96,3 +96,14 @@ metadata:
   {{- include "helm-charts-k8s.labels" . | nindent 4 }}
   annotations:
     {{- toYaml .Values.utilsContainer.serviceAccount.annotations | nindent 4 }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: amd-network-operator-cni-plugins
+  labels:
+    app.kubernetes.io/component: amd-nic
+    app.kubernetes.io/part-of: amd-nic
+  {{- include "helm-charts-k8s.labels" . | nindent 4 }}
+  annotations:
+    {{- toYaml .Values.cniPlugins.serviceAccount.annotations | nindent 4 }}

--- a/helm-charts-k8s/values.yaml
+++ b/helm-charts-k8s/values.yaml
@@ -129,6 +129,9 @@ configManager:
 utilsContainer:
   serviceAccount:
     annotations: {}
+cniPlugins:
+  serviceAccount:
+    annotations: {}
 global:
   proxy:
     env: {}


### PR DESCRIPTION
* Add CNI plugins service account and values for K8s Helm chart

- Add cniPlugins.serviceAccount.annotations to values.yaml
- Add CNI plugins service account to serviceaccount.yaml template
- Fixes helm lint error: nil pointer evaluating cniPlugins.serviceAccount
- Required for K8s Helm chart build to support CNI plugins RBAC

The CNI plugins service account is needed in vanilla K8s deployments even though the RBAC file is removed (OpenShift-specific).

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

* Address review comments

Signed-off-by: Yuva Shankar <11082310+yuva29@users.noreply.github.com>

---------

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
