### PR TITLE
[CP 300] Fix multus config detection to support both .conf and .conflist formats (#300)

### DIFF
--- a/hack/multus/values.yaml
+++ b/hack/multus/values.yaml
@@ -8,4 +8,5 @@ rbac:
 cniBinDir: /opt/cni/bin
 multusConfig:
   confDir: /etc/cni/net.d
-  fileName: 00-multus.conf
+  # Note: Multus auto-detects config format and creates either 00-multus.conf or 00-multus.conflist
+  # based on the existing primary CNI plugin configuration (e.g., Flannel uses .conflist in K3s)

--- a/helm-charts-k8s/Chart.lock
+++ b/helm-charts-k8s/Chart.lock
@@ -9,4 +9,4 @@ dependencies:
   repository: file://./charts/multus
   version: 1.0.0
 digest: sha256:04b5697c8fd25d5cb6cac27cf0248a255fd8a31e9cd3c9b7b8f114eedf788eab
-generated: "2026-01-23T23:58:28.730788736Z"
+generated: "2026-04-15T19:26:17.705254247Z"

--- a/helm-charts-k8s/README.md
+++ b/helm-charts-k8s/README.md
@@ -128,7 +128,6 @@ Kubernetes: `>= 1.29.0-0`
 | multus.image.repository | string | `"ghcr.io/k8snetworkplumbingwg/multus-cni"` |  |
 | multus.image.tag | string | `"v4.2.2"` |  |
 | multus.multusConfig.confDir | string | `"/etc/cni/net.d"` |  |
-| multus.multusConfig.fileName | string | `"00-multus.conf"` |  |
 | multus.rbac.create | bool | `true` |  |
 | multus.serviceAccountName | string | `"multus"` |  |
 

--- a/helm-charts-k8s/charts/multus/values.yaml
+++ b/helm-charts-k8s/charts/multus/values.yaml
@@ -8,4 +8,5 @@ rbac:
 cniBinDir: /opt/cni/bin
 multusConfig:
   confDir: /etc/cni/net.d
-  fileName: 00-multus.conf
+  # Note: Multus auto-detects config format and creates either 00-multus.conf or 00-multus.conflist
+  # based on the existing primary CNI plugin configuration (e.g., Flannel uses .conflist in K3s)

--- a/internal/deviceplugin/deviceplugin.go
+++ b/internal/deviceplugin/deviceplugin.go
@@ -35,7 +35,16 @@ const (
 	DevicePluginName          = "device-plugin"
 )
 
-func GenerateCommonDevicePluginSpec(nwConfig *amdv1alpha1.NetworkConfig) *protos.DevicePluginSpec {
+// buildMultusCheckCommand returns a shell command that checks if Multus config exists.
+// Returns true (waits) when config is missing, false (exits loop) when config is found.
+func buildMultusCheckCommand(isOpenShift bool) string {
+	if isOpenShift {
+		return "( ! ls /host/etc/cni/net.d/*multus*.conf >/dev/null 2>&1 && ! ls /host/etc/cni/net.d/*multus*.conflist >/dev/null 2>&1 && ! ls /host/etc/kubernetes/cni/net.d/*multus*.conf >/dev/null 2>&1 && ! ls /host/etc/kubernetes/cni/net.d/*multus*.conflist >/dev/null 2>&1 )"
+	}
+	return "( ! ls /host/etc/cni/net.d/*multus*.conf >/dev/null 2>&1 && ! ls /host/etc/cni/net.d/*multus*.conflist >/dev/null 2>&1 )"
+}
+
+func GenerateCommonDevicePluginSpec(nwConfig *amdv1alpha1.NetworkConfig, isOpenShift bool) *protos.DevicePluginSpec {
 	var dpOut protos.DevicePluginSpec
 	specIn := &nwConfig.Spec.DevicePlugin
 	simEnabled, _ := strconv.ParseBool(os.Getenv("SIM_ENABLE"))
@@ -68,24 +77,27 @@ func GenerateCommonDevicePluginSpec(nwConfig *amdv1alpha1.NetworkConfig) *protos
 			},
 		},
 	}
+
+	multusCheck := buildMultusCheckCommand(isOpenShift)
+
 	if !simEnabled {
 		initContainer.Command = []string{
 			"sh", "-c",
-			`while [ ! -d /sys/class/infiniband ] ||
+			fmt.Sprintf(`while [ ! -d /sys/class/infiniband ] ||
 				[ ! -d /sys/class/infiniband_verbs ] ||
 				[ ! -d /sys/module/ionic/drivers ] ||
-				! ls /host/etc/cni/net.d/*multus*.conf >/dev/null 2>&1; do
+				%s; do
 					echo "Waiting for AMD ionic driver and Multus CNI config to be ready"
 					sleep 2
-			done`,
+			done`, multusCheck),
 		}
 	} else {
 		initContainer.Command = []string{
 			"sh", "-c",
-			`while [ ! -f /host/etc/cni/net.d/*multus*.conf ]; do
-				echo "Waiting for Multus CNI config to be present in /etc/cni/net.d"
+			fmt.Sprintf(`while %s; do
+				echo "Waiting for Multus CNI config to be present"
 				sleep 2
-			done`,
+			done`, multusCheck),
 		}
 	}
 


### PR DESCRIPTION

* Fix multus config detection to support both .conf and .conflist formats

Multus auto-detects CNI config format based on primary CNI plugin. In K3s with Flannel, it creates .conflist instead of .conf.

- Update device plugin init container to check for *multus*.conf*
- Remove unused fileName from multus values.yaml
- Add comment explaining auto-detection behavior



* Address review comments
