### PR TITLE
Add SBR to wordlist to fix spelling check error

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -135,6 +135,7 @@ roce
 ROCm
 RollingUpdate
 SAR
+SBR
 serverName
 ServiceAccount
 ServiceAccounts


### PR DESCRIPTION
Add SBR (Source-Based Routing) to wordlist to resolve spell check failures. SBR is a valid CNI plugin acronym used in documentation.

