### PR TITLE
Update version to v1.2.0 for release (#301)

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -12,6 +12,7 @@ bearerTokenFile
 bool
 Bringup
 caFile
+cardinality
 certFile
 clientCAConfigMap
 clientName
@@ -30,6 +31,7 @@ controllerManager
 CoreOS
 coredns
 cpu
+CRI
 CRD
 crds
 CRDs
@@ -37,6 +39,7 @@ CronJob
 CronJobs
 CRs
 cryptographic
+CVEs
 cvf
 DaemonSet
 DaemonSets
@@ -52,6 +55,8 @@ disableHttps
 DockerHub
 EnableNodeLabeller
 etcd
+ethtool
+FEC
 Frontend
 Grafana
 gRPC
@@ -88,6 +93,7 @@ kubectl
 Labeller
 labeller
 lifecycle
+LIF
 MaxUnavailable
 MetricsExporter
 MetricsExporterSpec
@@ -120,6 +126,7 @@ oyaml
 pci
 Pensando
 Pollara
+QP
 rbac
 rbacConfig
 RCCL

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ endif
 
 # PROJECT_VERSION defines the project version.
 # Update this value when you upgrade the version of your project.
-PROJECT_VERSION ?= v1.1.0
+PROJECT_VERSION ?= v1.2.0
 
 ####################################
 # Network Operator Image Build variables

--- a/docs/_static/cluster-validation-job.yaml
+++ b/docs/_static/cluster-validation-job.yaml
@@ -32,7 +32,7 @@ data:
                   emptyDir: {}
               initContainers:
                 - name: wait-for-worker-pods
-                  image: docker.io/rocm/network-operator-utils:v1.1.0
+                  image: docker.io/rocm/network-operator-utils:v1.2.0
                   imagePullPolicy: Always
                   envFrom:
                     - configMapRef:
@@ -347,7 +347,7 @@ spec:
               args: ['-c', '/fluent-bit/etc/fluent-bit.conf']
           containers:
             - name: submit-mpijob
-              image: docker.io/rocm/network-operator-utils:v1.1.0
+              image: docker.io/rocm/network-operator-utils:v1.2.0
               imagePullPolicy: Always
               command: ["/bin/bash", "-c"]
               envFrom:

--- a/docs/device_plugin/deviceplugin.md
+++ b/docs/device_plugin/deviceplugin.md
@@ -16,14 +16,14 @@ spec:
         # Enable the Node Labeller component (default: true)
         enableNodeLabeller: true
 
-        # Specify the Node Labeller image (default: docker.io/rocm/k8s-network-node-labeller:v1.1.0)
-        nodeLabellerImage: "docker.io/rocm/k8s-network-node-labeller:v1.1.0"
+        # Specify the Node Labeller image (default: docker.io/rocm/k8s-network-node-labeller:v1.2.0)
+        nodeLabellerImage: "docker.io/rocm/k8s-network-node-labeller:v1.2.0"
 
         # Node labeller image pull policy
         nodeLabellerImagePullPolicy: Always
 
-        # Specify the Device Plugin image (default: docker.io/rocm/k8s-network-device-plugin:v1.1.0)
-        devicePluginImage: "docker.io/rocm/k8s-network-device-plugin:v1.1.0"
+        # Specify the Device Plugin image (default: docker.io/rocm/k8s-network-device-plugin:v1.2.0)
+        devicePluginImage: "docker.io/rocm/k8s-network-device-plugin:v1.2.0"
 
         # Device plugin image pull policy
         devicePluginImagePullPolicy: Always

--- a/docs/installation/kubernetes-helm-operators.md
+++ b/docs/installation/kubernetes-helm-operators.md
@@ -180,7 +180,7 @@ helm install amd-network-operator rocm-network/network-operator-charts \
   --create-namespace \
   --set kmm.enabled=false \
   --set node-feature-discovery.enabled=false \
-  --version=v1.1.0
+  --version=v1.2.0
 ```
 
 Then during this step only the network operator and multus CNI pods would be brought up in the new namespace `kube-amd-network`:

--- a/docs/installation/kubernetes-helm.md
+++ b/docs/installation/kubernetes-helm.md
@@ -111,7 +111,7 @@ Basic installation:
 helm install amd-network-operator rocm-network/network-operator-charts \
   --namespace kube-amd-network \
   --create-namespace \
-  --version=v1.1.0
+  --version=v1.2.0
 ```
 
 ```{note}
@@ -143,7 +143,7 @@ helm show values rocm/network-operator-charts
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | controllerManager.manager.image.repository | string | `"docker.io/rocm/network-operator"` | AMD Network operator controller manager image repository |
-| controllerManager.manager.image.tag | string | `"v1.1.0"` | AMD Network operator controller manager image tag |
+| controllerManager.manager.image.tag | string | `"v1.2.0"` | AMD Network operator controller manager image tag |
 | controllerManager.manager.imagePullPolicy | string | `"Always"` | Image pull policy for AMD Network operator controller manager pod |
 | controllerManager.manager.imagePullSecrets | string | `""` | Image pull secret name for pulling AMD Network operator controller manager image if registry needs credential to pull image |
 | controllerManager.manager.resources.limits.cpu | string | `"1000m"` | CPU limits for the controller manager. Consider increasing for large clusters |
@@ -235,7 +235,7 @@ You can apply resource changes by updating your values.yaml file and upgrading t
 helm upgrade amd-network-operator rocm/network-operator-charts \
   --debug \
   --namespace kube-amd-network \
-  --version=v1.1.0
+  --version=v1.2.0
   -f values.yaml
 ```
 

--- a/docs/installation/networkconfig-full.md
+++ b/docs/installation/networkconfig-full.md
@@ -63,7 +63,7 @@ spec:
         gracePeriodSeconds: -2
   # Device plugin and Node labeller config
   devicePlugin:
-    devicePluginImage: docker.io/rocm/k8s-network-device-plugin:v1.1.0
+    devicePluginImage: docker.io/rocm/k8s-network-device-plugin:v1.2.0
     devicePluginImagePullPolicy: "Always"
     devicePluginTolerations:
       - key: "example-key"
@@ -75,7 +75,7 @@ spec:
         value: "example-value2"
         effect: "NoExecute"
     enableNodeLabeller: True
-    nodeLabellerImage: docker.io/rocm/k8s-network-node-labeller:v1.1.0
+    nodeLabellerImage: docker.io/rocm/k8s-network-node-labeller:v1.2.0
     nodeLabellerImagePullPolicy: "Always"
     nodeLabellerTolerations:
       - key: "example-key"
@@ -95,7 +95,7 @@ spec:
     port: 5001
     serviceType: "NodePort"
     nodePort: 32501
-    image: docker.io/rocm/device-metrics-exporter:nic-v1.1.0
+    image: docker.io/rocm/device-metrics-exporter:nic-v1.2.0
     imagePullPolicy: "Always"
     imageRegistrySecret:
       name: my-secret
@@ -129,7 +129,7 @@ spec:
   secondaryNetwork:
     cniPlugins:
       enable: True
-      image: docker.io/rocm/k8s-cni-plugins:v1.1.0
+      image: docker.io/rocm/k8s-cni-plugins:v1.2.0
       imagePullPolicy: "Always"
       imageRegistrySecret:
         name: my-secret
@@ -147,7 +147,7 @@ spec:
     initContainerImage: busybox:1.36
     utilsContainer:
       # -- network operator utility container image used for driver upgrade
-      image: docker.io/rocm/network-operator-utils:v1.1.0
+      image: docker.io/rocm/network-operator-utils:v1.2.0
       # -- utility container image pull policy
       imagePullPolicy: IfNotPresent
       # -- utility container image pull secret, e.g. {"name": "mySecretName"}

--- a/docs/installation/networkconfig.md
+++ b/docs/installation/networkconfig.md
@@ -27,8 +27,8 @@ spec:
   # Device plugin and Node labeller config
   devicePlugin:
     enableNodeLabeller: True
-    nodeLabellerImage: docker.io/rocm/k8s-network-node-labeller:v1.1.0
-    devicePluginImage: docker.io/rocm/k8s-network-device-plugin:v1.1.0
+    nodeLabellerImage: docker.io/rocm/k8s-network-node-labeller:v1.2.0
+    devicePluginImage: docker.io/rocm/k8s-network-device-plugin:v1.2.0
 
   # Metrics exporter config
   metricsExporter:
@@ -37,13 +37,13 @@ spec:
     serviceType: "NodePort"
     nodePort: 32501
     hostNetwork: true
-    image: docker.io/rocm/device-metrics-exporter:nic-v1.1.0
-  
+    image: docker.io/rocm/device-metrics-exporter:nic-v1.2.0
+
   # Secondary network config
   secondaryNetwork:
     cniPlugins:
       enable: True
-      image: docker.io/rocm/k8s-cni-plugins:v1.1.0
+      image: docker.io/rocm/k8s-cni-plugins:v1.2.0
   
   # Specify the node to be managed by this NetworkConfig Custom Resource
   selector:
@@ -80,8 +80,8 @@ To check the full spec of `NetworkConfig` definition, run `kubectl get crds netw
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `devicePluginImage` | AMD Network device plugin image | `docker.io/rocm/k8s-network-device-plugin:v1.1.0` |
-| `nodeLabellerImage` | Node labeller image | `docker.io/rocm/k8s-network-node-labeller:v1.1.0` |
+| `devicePluginImage` | AMD Network device plugin image | `docker.io/rocm/k8s-network-device-plugin:v1.2.0` |
+| `nodeLabellerImage` | Node labeller image | `docker.io/rocm/k8s-network-node-labeller:v1.2.0` |
 | `imageRegistrySecret.name` | Name of registry credentials secret<br> to pull device plugin / node labeller image | |
 | `enableNodeLabeller` | enable / disable node labeller | `true` |
 
@@ -101,7 +101,7 @@ To check the full spec of `NetworkConfig` definition, run `kubectl get crds netw
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `cniPlugins.enable` | Enable/disable CNI plugins | `false` |
-| `cniPlugins.image` | CNI plugins image | `docker.io/rocm/cni-plugins:v1.1.0`|
+| `cniPlugins.image` | CNI plugins image | `docker.io/rocm/k8s-cni-plugins:v1.2.0`|
 | `cniPlugins.imageRegistrySecret.name` | Name of registry credentials secret<br> to pull metrics exporter image | |
 
 #### `spec.selector` Parameters

--- a/docs/metrics/exporter.md
+++ b/docs/metrics/exporter.md
@@ -16,7 +16,7 @@ spec:
         enable: true
 
         # Specify the Metrics Exporter image
-        image: "docker.io/rocm/device-metrics-exporter:nic-v1.1.0"
+        image: "docker.io/rocm/device-metrics-exporter:nic-v1.2.0"
 
         # Image pull policy (default: IfNotPresent, or Always if tag is :latest)
         imagePullPolicy: "IfNotPresent"

--- a/docs/upgrades/componentupgrades.md
+++ b/docs/upgrades/componentupgrades.md
@@ -56,7 +56,7 @@ The current image the Device Plugin Daemonset is using can be checked by using `
 ```yaml
 device-plugin:
     Container ID:   containerd://b1aaa67ebdd87d4ef0f2a32b76b428068d24c28ced3e86c3c5caba39bb5689a4
-    Image:          rocm/k8s-network-device-plugin:v1.1.0
+    Image:          rocm/k8s-network-device-plugin:v1.2.0
 ```
 
 ### 3. Upgrade the Image of Device Plugin Daemonset
@@ -71,7 +71,7 @@ Old CR:
 
 ```yaml
     devicePlugin:
-        devicePluginImage: rocm/k8s-network-device-plugin:v1.1.0
+        devicePluginImage: rocm/k8s-network-device-plugin:v1.2.0
 ```
 
 Updated CR:
@@ -109,7 +109,7 @@ Old CR:
     enable: True
     serviceType: "ClusterIP"
     port: 5001
-    image: rocm/device-metrics-exporter:nic-v1.1.0
+    image: rocm/device-metrics-exporter:nic-v1.2.0
 ```
 
 Updated CR:
@@ -119,7 +119,7 @@ Updated CR:
     enable: True
     serviceType: "ClusterIP"
     port: 5001
-    image: rocm/device-metrics-exporter:nic-v1.1.0
+    image: rocm/device-metrics-exporter:nic-v1.2.0
     upgradePolicy:
       upgradeStrategy: OnDelete
 ```

--- a/docs/upgrades/upgrade.md
+++ b/docs/upgrades/upgrade.md
@@ -42,7 +42,7 @@ Upgrade the operator using the following command:
 ```bash
 helm upgrade amd-network-operator rocm/network-operator-charts \
     -n kube-amd-network \
-    --version=v1.1.0 \
+    --version=v1.2.0 \
     --recreate-pods \
     --debug
 ```
@@ -54,10 +54,10 @@ helm upgrade amd-network-operator rocm/network-operator-charts \
 # Perform helm upgrade
 helm upgrade amd-network-operator rocm/network-operator-charts \
   -n kube-amd-network \
-  --version=v1.1.0 \
+  --version=v1.2.0 \
   --debug \
   --set controllerManager.manager.image.repository=docker.io/rocm/network-operator \
-  --set controllerManager.manager.image.tag=v1.1.0 
+  --set controllerManager.manager.image.tag=v1.2.0
 ```
 
 ```{note}

--- a/example/networkconfig.yaml
+++ b/example/networkconfig.yaml
@@ -42,12 +42,12 @@ spec:
     enableNodeLabeller: True
 
     # node labeller image
-    # default value is rocm/k8s-network-node-labeller:v1.1.0
-    nodeLabellerImage: docker.io/rocm/k8s-network-node-labeller:v1.1.0
+    # default value is rocm/k8s-network-node-labeller:v1.2.0
+    nodeLabellerImage: docker.io/rocm/k8s-network-node-labeller:v1.2.0
 
     # Specify the device plugin image
-    # default value is rocm/k8s-network-device-plugin:v1.1.0
-    devicePluginImage: docker.io/rocm/k8s-network-device-plugin:v1.1.0
+    # default value is rocm/k8s-network-device-plugin:v1.2.0
+    devicePluginImage: docker.io/rocm/k8s-network-device-plugin:v1.2.0
 
     # Specify Device Plugin image pull policy
     # default value is IfNotPresent for valid tags, Always for no tag or "latest" tag
@@ -77,8 +77,8 @@ spec:
     nodePort: 32501
 
     # exporter image
-    # default value is docker.io/rocm/device-metrics-exporter:nic-v1.1.0
-    image: docker.io/rocm/device-metrics-exporter:nic-v1.1.0
+    # default value is docker.io/rocm/device-metrics-exporter:nic-v1.2.0
+    image: docker.io/rocm/device-metrics-exporter:nic-v1.2.0
 
     # image pull policy for metrics exporter
     # default value is IfNotPresent for valid tags, Always for no tag or "latest" tag
@@ -101,7 +101,7 @@ spec:
     # CNI plugin configuration
     cniPlugins:
       enable: True
-      image: docker.io/rocm/k8s-cni-plugins:v1.1.0
+      image: docker.io/rocm/k8s-cni-plugins:v1.2.0
       imagePullPolicy: "Always"
       # image registry secret used to pull/push images
       imageRegistrySecret:
@@ -112,7 +112,7 @@ spec:
     initContainerImage: busybox:1.36
     utilsContainer:
       # -- network operator utility container image used for driver upgrade
-      image: docker.io/rocm/network-operator-utils:v1.1.0
+      image: docker.io/rocm/network-operator-utils:v1.2.0
       # -- utility container image pull policy
       imagePullPolicy: IfNotPresent
       # -- utility container image pull secret, e.g. {"name": "mySecretName"}

--- a/hack/k8s-patch/metadata-patch/Chart.yaml
+++ b/hack/k8s-patch/metadata-patch/Chart.yaml
@@ -21,7 +21,7 @@ keywords:
   - monitoring
 
 kubeVersion: ">= 1.29.0-0"
-version: v1.1.0
+version: v1.2.0
 appVersion: dev
 
 dependencies:

--- a/hack/openshift-patch/metadata-patch/Chart.yaml
+++ b/hack/openshift-patch/metadata-patch/Chart.yaml
@@ -20,7 +20,7 @@ keywords:
   - monitoring
 
 kubeVersion: ">= 1.29.0-0"
-version: v1.1.0
+version: v1.2.0
 appVersion: dev
 
 dependencies:

--- a/helm-charts-k8s/Chart.lock
+++ b/helm-charts-k8s/Chart.lock
@@ -9,4 +9,4 @@ dependencies:
   repository: file://./charts/multus
   version: 1.0.0
 digest: sha256:04b5697c8fd25d5cb6cac27cf0248a255fd8a31e9cd3c9b7b8f114eedf788eab
-generated: "2026-04-22T03:20:07.115869874Z"
+generated: "2026-04-22T19:21:21.895580993Z"

--- a/helm-charts-k8s/Chart.yaml
+++ b/helm-charts-k8s/Chart.yaml
@@ -21,7 +21,7 @@ keywords:
   - monitoring
 
 kubeVersion: ">= 1.29.0-0"
-version: v1.1.0
+version: v1.2.0
 appVersion: dev
 
 dependencies:

--- a/helm-charts-k8s/README.md
+++ b/helm-charts-k8s/README.md
@@ -15,10 +15,9 @@ For detailed component information, see [Component Overview](docs/overview.md).
 ## License
 
 The AMD Network Operator is licensed under the [Apache License 2.0](LICENSE).
-
 # network-operator-charts
 
-![Version: v1.1.0](https://img.shields.io/badge/Version-v1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: dev](https://img.shields.io/badge/AppVersion-dev-informational?style=flat-square)
+![Version: v1.2.0](https://img.shields.io/badge/Version-v1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: dev](https://img.shields.io/badge/AppVersion-dev-informational?style=flat-square)
 
 AMD Network Operator simplifies the deployment and management of AMD AINICs within Kubernetes clusters.
 

--- a/helm-charts-k8s/crds/networkconfig-crd.yaml
+++ b/helm-charts-k8s/crds/networkconfig-crd.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     app.kubernetes.io/component: amd-network
     app.kubernetes.io/part-of: amd-network
-    helm.sh/chart: network-operator-charts-v1.1.0
+    helm.sh/chart: network-operator-charts-v1.2.0
     app.kubernetes.io/name: network-operator-charts
     app.kubernetes.io/instance: amd-network
     app.kubernetes.io/version: "dev"

--- a/internal/controllers/upgrademgr.go
+++ b/internal/controllers/upgrademgr.go
@@ -64,7 +64,7 @@ import (
 )
 
 const (
-	defaultUtilsImage          = "docker.io/rocm/network-operator-utils:v1.1.0"
+	defaultUtilsImage          = "docker.io/rocm/network-operator-utils:v1.2.0"
 	defaultOcUtilsImage        = "docker.io/rocm/network-operator-utils:rhubi-latest"
 	defaultSAName              = "amd-network-operator-utils-container"
 	driverUpgradeStateLabelKey = "operator.amd.com/network-driver-upgrade-state"

--- a/internal/deviceplugin/deviceplugin.go
+++ b/internal/deviceplugin/deviceplugin.go
@@ -30,7 +30,7 @@ import (
 
 const (
 	defaultInitContainerImage    = "busybox:1.36"
-	defaultDevicePluginImage     = "docker.io/rocm/k8s-network-device-plugin:v1.1.0"
+	defaultDevicePluginImage     = "docker.io/rocm/k8s-network-device-plugin:v1.2.0"
 	defaultDevicePluginConfigMap = "amd-network-operator-device-plugin-config"
 	devicePluginSAName           = "amd-network-operator-device-plugin"
 	DevicePluginName             = "device-plugin"

--- a/internal/metricsexporter/exporter.go
+++ b/internal/metricsexporter/exporter.go
@@ -34,7 +34,7 @@ const (
 	exporterSAName                    = "amd-network-operator-metrics-exporter"
 	kubeRBACSAName                    = "amd-network-operator-metrics-exporter-rbac-proxy"
 	StaticAuthSecretName              = ExporterName + "-static-auth-config"
-	defaultMetricsExporterImage       = "docker.io/rocm/device-metrics-exporter:nic-v1.1.0"
+	defaultMetricsExporterImage       = "docker.io/rocm/device-metrics-exporter:nic-v1.2.0"
 	defaultInitContainerImage         = "busybox:1.36"
 	svcLabel                          = "app.kubernetes.io/service"
 )

--- a/internal/nodelabeller/nodelabeller.go
+++ b/internal/nodelabeller/nodelabeller.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	defaultNodeLabellerUbiImage = "docker.io/rocm/k8s-network-node-labeller:v1.1.0"
+	defaultNodeLabellerUbiImage = "docker.io/rocm/k8s-network-node-labeller:v1.2.0"
 	defaultInitContainerImage   = "busybox:1.36"
 	defaultBlacklistFileName    = "blacklist-ionic-netop.conf"
 	nodeLabellerSAName          = "amd-network-operator-node-labeller"

--- a/internal/secondarynetwork/cniplugins.go
+++ b/internal/secondarynetwork/cniplugins.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	defaultCNIPluginsImage = "docker.io/rocm/k8s-cni-plugins:v1.1.0"
+	defaultCNIPluginsImage = "docker.io/rocm/k8s-cni-plugins:v1.2.0"
 	CNIPluginsName         = "cni-plugins"
 	cniPluginsSAName       = "amd-network-operator-cni-plugins"
 )

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -40,7 +40,7 @@ const (
 	ResourceNamingStrategyFlag  = "resource_naming_strategy"
 	SingleStrategy              = "single"
 	MixedStrategy               = "mixed"
-	DefaultUtilsImage           = "docker.io/rocm/network-operator-utils:v1.1.0"
+	DefaultUtilsImage           = "docker.io/rocm/network-operator-utils:v1.2.0"
 
 	// worker pod related constants
 	KindNetworkConfig      = "NetworkConfig"

--- a/internal/utils_container/Dockerfile
+++ b/internal/utils_container/Dockerfile
@@ -3,8 +3,8 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
 LABEL name="amd-network-operator-utils"
 LABEL maintainer="sriram.ravishankar@amd.com,yan.sun3@amd.com"
 LABEL vendor="Advanced Micro Devices, Inc."
-LABEL version="v1.1.0"
-LABEL release="v1.1.0"
+LABEL version="v1.2.0"
+LABEL release="v1.2.0"
 LABEL summary="AMD Network Operator Utility Image"
 LABEL description="The AMD Network Operator utils image is a utility image used by the AMD Network Operator. The operator controller employs this image as the container's base layer to automate tasks on target worker nodes."
 


### PR DESCRIPTION
* Update version to v1.2.0 for release

- Bump PROJECT_VERSION in Makefile and build files
- Update all Go code image defaults to v1.2.0
- Update Helm charts and CRDs to v1.2.0
- Update documentation examples to reference v1.2.0
- Update example configurations and validation job

* Address review comments