### PR TITLE
fix: update CSV description, add NFD required CRD, fix OpenShift chart docs (#331)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ YAML_FILES=config/samples/amd.com_networkconfigs.yaml config/manifests/bases/amd
 CRD_YAML_FILES = networkconfig-crd.yaml
 K8S_KMM_CRD_YAML_FILES=module-crd.yaml nodemodulesconfig-crd.yaml
 OPENSHIFT_KMM_CRD_YAML_FILES=module-crd.yaml nodemodulesconfig-crd.yaml
-OPENSHIFT_CLUSTER_NFD_CRD_YAML_FILES=nodefeature-crd.yaml nodefeaturediscovery-crd.yaml nodefeaturerule-crd.yaml noderesourcetopology-crd.yaml
+OPENSHIFT_CLUSTER_NFD_CRD_YAML_FILES=nodefeature-crd.yaml nodefeaturediscovery-crd.yaml nodefeaturerule-crd.yaml
 
 ifdef OPENSHIFT
 $(info selected openshift)

--- a/config/manifests/bases/amd-network-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/amd-network-operator.clusterserviceversion.yaml
@@ -7,7 +7,7 @@ metadata:
     categories: AI/Machine Learning,Networking,Monitoring
     containerImage: registry.test.pensando.io:5000/amd-network-operator:dev
     description: |-
-      Operator responsible for deploying AMD Network kernel drivers, device plugin, device test runner and device metrics exporter
+      Operator responsible for deploying AMD Network kernel drivers, device plugin, node labeller and device metrics exporter
       For more information, visit [documentation](https://instinct.docs.amd.com/projects/network-operator/en/latest/)
     devicePluginImage: docker.io/rocm/k8s-network-device-plugin:v0.0.1
     features.operators.openshift.io/disconnected: "true"


### PR DESCRIPTION
Cherry-pick of https://github.com/pensando/network-operator/pull/331

- Fix CSV description: replace "device test runner" with "node labeller" (network operator doesn't have a test runner component)
- Fix Makefile: remove stale noderesourcetopology-crd.yaml from OPENSHIFT_CLUSTER_NFD_CRD_YAML_FILES (no longer exists in NFD release-4.16, was causing make helm-openshift to fail)
- Add NodeFeatureDiscovery CR creation step to OpenShift prerequisites in installation guide

**Dropped:** `bundle/manifests/amd-network-operator.clusterserviceversion.yaml` — `bundle/` directory does not exist on ROCm main.