### PR TITLE
Generate llms files with rocm_docs_generate_llms

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,6 +20,7 @@ html_theme = "rocm_docs_theme"
 html_theme_options = {
     "flavor": "instinct",
     "link_main_doc": True,
+    "use_download_button": True,
     # Add any additional theme options here
 }
 extensions = [
@@ -30,6 +31,11 @@ extensions = [
 # Table of contents
 external_toc_path = "./sphinx/_toc.yml"
 external_toc_exclude_missing = False
+
+# Generate llms.txt and llms-full.txt after each build (the llms.txt standard,
+# https://llmstxt.org/). See the rocm-docs-core guide:
+# https://rocm.docs.amd.com/projects/rocm-docs-core/en/latest/user_guide/llms.html
+rocm_docs_generate_llms = True
 
 # Only for new projects. Remove when stable.
 nitpicky = True

--- a/docs/sphinx/requirements.in
+++ b/docs/sphinx/requirements.in
@@ -1,3 +1,3 @@
-rocm-docs-core
+rocm-docs-core[llms]==1.38.0
 sphinx-reredirects
 sphinx-tags==0.4

--- a/docs/sphinx/requirements.txt
+++ b/docs/sphinx/requirements.txt
@@ -48,6 +48,7 @@ docutils==0.21.2
     #   myst-parser
     #   pydata-sphinx-theme
     #   sphinx
+    #   sphinx-markdown-builder
 executing==2.2.1
     # via stack-data
 fastjsonschema==2.21.2
@@ -130,6 +131,7 @@ nest-asyncio==1.6.0
 packaging==25.0
     # via
     #   ipykernel
+    #   pydata-sphinx-theme
     #   sphinx
 parso==0.8.5
     # via jedi
@@ -147,7 +149,7 @@ pure-eval==0.2.3
     # via stack-data
 pycparser==2.23
     # via cffi
-pydata-sphinx-theme==0.16.1
+pydata-sphinx-theme==0.15.4
     # via
     #   rocm-docs-core
     #   sphinx-book-theme
@@ -185,7 +187,7 @@ requests==2.32.5
     # via
     #   pygithub
     #   sphinx
-rocm-docs-core==1.26.0
+rocm-docs-core[llms]==1.38.0
     # via -r requirements.in
 roman-numerals-py==3.1.0
     # via sphinx
@@ -212,16 +214,19 @@ sphinx==8.2.3
     #   sphinx-copybutton
     #   sphinx-design
     #   sphinx-external-toc
+    #   sphinx-markdown-builder
     #   sphinx-notfound-page
     #   sphinx-reredirects
     #   sphinx-tags
-sphinx-book-theme==1.1.3
+sphinx-book-theme==1.1.4
     # via rocm-docs-core
 sphinx-copybutton==0.5.2
     # via rocm-docs-core
 sphinx-design==0.6.1
     # via rocm-docs-core
 sphinx-external-toc==1.0.1
+    # via rocm-docs-core
+sphinx-markdown-builder==0.6.10
     # via rocm-docs-core
 sphinx-notfound-page==1.1.0
     # via rocm-docs-core
@@ -246,7 +251,9 @@ sqlalchemy==2.0.44
 stack-data==0.6.3
     # via ipython
 tabulate==0.9.0
-    # via jupyter-cache
+    # via
+    #   jupyter-cache
+    #   sphinx-markdown-builder
 tornado==6.5.2
     # via
     #   ipykernel


### PR DESCRIPTION
## Motivation

Enable llms.txt / llms-full.txt generation for the Network Operator docs, so the site publishes machine-readable documentation following the llms.txt standard (https://llmstxt.org/). This aligns the project with the shared approach used across the Instinct documentation set (k8s-device-plugin, container-toolkit, gpu-operator, gpu-cluster-networking, amdgpu-docs, instinct-docs), using the built-in support in rocm-docs-core.

## Technical Details

- Enable generation via rocm_docs_generate_llms = True in docs/conf.py, which produces both llms.txt and llms-full.txt from the resolved doctree at build time.
- Add use_download_button: True to html_theme_options for the per-page Markdown download button.
- Pin rocm-docs-core to 1.38.0 and add the [llms] extra in docs/sphinx/requirements.in (previously unpinned, resolving to 1.26.0); regenerate requirements.txt (Python 3.12, matching the existing lockfile header), which pulls in sphinx-markdown-builder. Existing pins (sphinx-reredirects, sphinx-tags) are preserved.

The rocm-docs-core dependency is now pinned rather than floating: the [llms] extra requires a version that ships the generator, and an unpinned spec would resolve to the latest 1.39.0, whose published wheel has a malformed projects.yaml that breaks the build (already fixed upstream on develop, pending a patch release). Pinning to 1.38.0 avoids that.

## Test Plan

- Regenerated docs/sphinx/requirements.txt with pip-compile under Python 3.12; confirmed the [llms] extra and existing dependencies resolve.
- Ran a full sphinx-build -b html in a clean python:3.13-slim container (matching the .readthedocs.yaml build Python) with the pinned requirements.
- Verified llms.txt and llms-full.txt are generated and inspected their content.

## Test Result

Build succeeds (build succeeded, 23 warnings) and logs Wrote llms.txt and llms-full.txt. Generated llms.txt (2 KB) has the correct # Network Operator header and indexes all pages; llms-full.txt (157 KB) has correct per-page sections with prose filtering. The 23 warnings are pre-existing, unrelated to this change.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.