### PR TITLE
docs: restructure CVF documentation and eliminate duplication

### DIFF
--- a/docker/roce-workload/README.md
+++ b/docker/roce-workload/README.md
@@ -12,10 +12,8 @@ Pre-built images are available on [Docker Hub](https://hub.docker.com/r/rocm/roc
 2. [Build Requirements](#build-requirements)
 3. [Build](#build)
 4. [Configuration](#configuration)
-5. [Verify the Image](#verify-the-image)
-6. [Included Tools](#included-tools)
-7. [Running RCCL Tests Manually](#running-rccl-tests-manually)
-8. [Usage with CVF](#usage-with-cvf)
+5. [Included Tools](#included-tools)
+6. [Running and Deploying](#running-and-deploying)
 
 ---
 
@@ -84,23 +82,6 @@ To reduce build time, set only the targets you need (e.g., `GPU_TARGETS="gfx942"
 
 ---
 
-## Verify the Image
-
-After building, verify all components are present (find your tag with `docker images | grep roce-workload`):
-
-```bash
-docker run --rm roce-workload:<tag> bash -c '
-  echo "RCCL:"; ls /root/rccl/build/release/librccl.so* | head -1
-  echo "ANP:"; find / -name "librccl-anp.so" 2>/dev/null | head -1
-  echo "RCCL tests:"; ls /root/rccl-tests/build/all_reduce_perf
-  echo "MPI:"; /root/ompi/install/bin/mpirun --version | head -1
-  echo "UCX:"; /root/ucx_build/bin/ucx_info -v | head -1
-  echo "show_gid:"; ls /usr/sbin/show_gid
-'
-```
-
----
-
 ## Included Tools
 
 - **`run_rccl.sh`** — standalone 2-node RCCL test runner. Configurable via environment variables:
@@ -120,139 +101,6 @@ docker run --rm roce-workload:<tag> bash -c '
 
 ---
 
-## Running RCCL Tests Manually
+## Running and Deploying
 
-> This section is for quick validation that the image works correctly. For fleet-wide cluster validation, use the [Cluster Validation Framework (CVF)](#usage-with-cvf).
-
-**Prerequisites:**
-
-- [AMD Network Operator](https://instinct.docs.amd.com/projects/network-operator/en/main/) deployed with a `NetworkConfig` CR
-- `amd-host-device-nad` [NetworkAttachmentDefinition](https://instinct.docs.amd.com/projects/network-operator/en/main/secondary_network/amd-host-device-cni.html) created
-- [AMD GPU Operator](https://instinct.docs.amd.com/projects/gpu-operator/en/latest/) deployed (for `amd.com/gpu` device resources)
-
-Each pod generates its own SSH key pair on startup. Before running MPI, exchange keys between pods:
-
-### 1. Deploy workload pods
-
-```bash
-kubectl apply -f - <<'EOF'
-apiVersion: v1
-kind: Pod
-metadata:
-  name: rccl-worker-0
-  labels:
-    app: rccl-test
-  annotations:
-    k8s.v1.cni.cncf.io/networks: amd-host-device-nad,amd-host-device-nad  # one entry per NIC
-spec:
-  restartPolicy: Never
-  containers:
-  - name: worker
-    image: rocm/roce-workload:ubuntu24_rocm-7.2_rccl-ainic-oob-fb67e5b_anp-v1.3.0_ainic-1.117.5-a-77
-    securityContext:
-      capabilities:
-        add: [IPC_LOCK]
-    resources:
-      requests:
-        amd.com/gpu: 8   # adjust to match your hardware
-        amd.com/nic: 2
-      limits:
-        amd.com/gpu: 8
-        amd.com/nic: 2
-    volumeMounts:
-    - name: shm
-      mountPath: /dev/shm
-  volumes:
-  - name: shm
-    emptyDir:
-      medium: Memory
-      sizeLimit: 4Gi
----
-apiVersion: v1
-kind: Pod
-metadata:
-  name: rccl-worker-1
-  labels:
-    app: rccl-test
-  annotations:
-    k8s.v1.cni.cncf.io/networks: amd-host-device-nad,amd-host-device-nad  # one entry per NIC
-spec:
-  affinity:
-    podAntiAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-      - labelSelector:
-          matchLabels:
-            app: rccl-test
-        topologyKey: kubernetes.io/hostname
-  restartPolicy: Never
-  containers:
-  - name: worker
-    image: rocm/roce-workload:ubuntu24_rocm-7.2_rccl-ainic-oob-fb67e5b_anp-v1.3.0_ainic-1.117.5-a-77
-    securityContext:
-      capabilities:
-        add: [IPC_LOCK]
-    resources:
-      requests:
-        amd.com/gpu: 8
-        amd.com/nic: 2
-      limits:
-        amd.com/gpu: 8
-        amd.com/nic: 2
-    volumeMounts:
-    - name: shm
-      mountPath: /dev/shm
-  volumes:
-  - name: shm
-    emptyDir:
-      medium: Memory
-      sizeLimit: 4Gi
-EOF
-```
-
-Adjust `amd.com/gpu` and `amd.com/nic` counts to match your hardware. The anti-affinity rule ensures pods land on different nodes automatically.
-
-**For VMs with VNICs (SR-IOV VFs):** replace `amd.com/nic` with `amd.com/vnic` and `amd-host-device-nad` with `vf-amd-host-device-nad` in the pod spec above.
-
-### 2. Exchange SSH keys
-
-```bash
-W0_KEY=$(kubectl exec rccl-worker-0 -- cat /root/.ssh/id_rsa.pub)
-W1_KEY=$(kubectl exec rccl-worker-1 -- cat /root/.ssh/id_rsa.pub)
-kubectl exec rccl-worker-0 -- bash -c "echo '$W1_KEY' >> /root/.ssh/authorized_keys"
-kubectl exec rccl-worker-1 -- bash -c "echo '$W0_KEY' >> /root/.ssh/authorized_keys"
-```
-
-### 3. Run RCCL test
-
-```bash
-# Get pod IPs
-W0_IP=$(kubectl get pod rccl-worker-0 -o jsonpath='{.status.podIP}')
-W1_IP=$(kubectl get pod rccl-worker-1 -o jsonpath='{.status.podIP}')
-
-# Run (GPUS_PER_NODE must match amd.com/gpu in the pod spec above)
-kubectl exec rccl-worker-0 -- env GPUS_PER_NODE=8 run_rccl.sh $W0_IP $W1_IP all_reduce_perf
-```
-
-Available collectives: `all_reduce_perf`, `broadcast_perf`, `reduce_scatter_perf`, `all_gather_perf`, `alltoall_perf`, `reduce_perf`, `scatter_perf`, `gather_perf`, `sendrecv_perf`
-
-A successful run prints a bandwidth table and ends with:
-
-```text
-# Avg bus bandwidth    : 6.66557
-```
-
-### 4. Cleanup
-
-```bash
-kubectl delete pod rccl-worker-0 rccl-worker-1
-```
-
----
-
-## Usage with CVF
-
-Set the image in the [Cluster Validation Framework](https://instinct.docs.amd.com/projects/network-operator/en/main/cluster_validation_framework/README.html) `config.yaml`:
-
-```yaml
-RCCL_WORKLOAD_IMAGE: "rocm/roce-workload:ubuntu24_rocm-7.2_rccl-ainic-oob-fb67e5b_anp-v1.3.0_ainic-1.117.5-a-77"
-```
+For deployment instructions (pod manifests, RCCL tests, CVF integration), see the [RoCE Workload Image documentation](https://instinct.docs.amd.com/projects/network-operator/en/latest/cluster_validation_framework/roce-workload.html).

--- a/docs/cluster_validation_framework/README.md
+++ b/docs/cluster_validation_framework/README.md
@@ -1,6 +1,6 @@
 # Cluster Validation and Job Scheduling Framework
 
-The **Cluster  Validation and Job Scheduling Framework** is a Kubernetes-based framework designed to periodically verify the health and readiness of worker nodes present in the cluster through active tests. This framework can also be used for validating a set of newly added worker nodes to the kubernetes cluster before scheduling distributed training,inference workloads on them.
+The **Cluster Validation and Job Scheduling Framework** is a Kubernetes-based framework designed to periodically verify the health and readiness of worker nodes present in the cluster through active tests. This framework can also be used for validating a set of newly added worker nodes to the Kubernetes cluster before scheduling distributed training, inference workloads on them.
 
 In addition to validation, this framework can be leveraged for scheduling and orchestrating distributed AI and HPC workloads, ensuring that performance-verified nodes participate in large-scale compute jobs.
 
@@ -80,6 +80,7 @@ This framework supports Gang Scheduling  by checking for Pod Running status and 
 
 3. **RCCL Test Execution**
    * A job manifest (like `MPIJob`) is applied dynamically using `kubectl apply`.
+   * The job uses the [RoCE workload image](roce-workload.md) which bundles ROCm, RCCL, MPI, and AINIC user-space libraries.
    * The job runs distributed or node-local workloads to test network, GPU, AINIC and system health.
 
 4. **Result Validation**
@@ -91,9 +92,9 @@ This framework supports Gang Scheduling  by checking for Pod Running status and 
 
 ---
 
-## 🚀 Deployment Steps
+## Deployment Steps
 
-## 1. Create ConfigMaps
+### 1. Create ConfigMaps
 
 [Download ConfigMap YAML](../_static/cluster-validation-config.yaml)
 
@@ -103,7 +104,7 @@ kubectl apply -f cluster-validation-config.yaml
 
 ---
 
-## 2. Deploy Cluster Validation Job
+### 2. Deploy Cluster Validation Job
 
 [Download CronJob YAML](../_static/cluster-validation-job.yaml)
 (CronJob + MPIJob Template + RBAC)
@@ -114,7 +115,7 @@ kubectl apply -f cluster-validation-job.yaml
 
 ---
 
-## 3. Verify CronJob
+### 3. Verify CronJob
 
 ```bash
 kubectl get cronjob cluster-validation-cron-job
@@ -123,25 +124,14 @@ kubectl get jobs
 
 ---
 
-## 4. Check Node Labels
+### 4. Check Node Labels
 
 ```bash
 kubectl get nodes --show-labels | grep cluster-validation-status
 kubectl describe node | grep "amd.com/cluster-validation\|Name:"
 ```
 
----
-
-## 5. Inspect Logs
-
-```bash
-kubectl logs job/cluster-validation-cron-job-<29379315>
-kubectl logs job/cluster-validation-mpi-job-<20251110-0715>-launcher
-```
-
----
-
-## Example Output Labels
+Example output labels:
 
 | Node   | Label                                       | Meaning                                                     |
 | ------ | ------------------------------------------- | ----------------------------------------------------------- |
@@ -151,9 +141,18 @@ kubectl logs job/cluster-validation-mpi-job-<20251110-0715>-launcher
 
 ---
 
+### 5. Inspect Logs
+
+```bash
+kubectl logs job/cluster-validation-cron-job-<29379315>
+kubectl logs job/cluster-validation-mpi-job-<20251110-0715>-launcher
+```
+
+---
+
 ## Notes for Operators
 
-* Update image tags (**[roce-workload](../roce-workload.md)**, **network-operator-utils**) as needed before deployment.
+* Update image tags (**[roce-workload](roce-workload.md)**, **network-operator-utils**) as needed before deployment.
 * Modify `cluster-validation-config.yaml` to align with your deployment environment.
 * Ensure `slotsPerWorker` and resource limits correspond to the underlying GPU and NIC configuration.  
 * Adjust `CronJob.spec` to set the job frequency.  

--- a/docs/cluster_validation_framework/roce-workload.md
+++ b/docs/cluster_validation_framework/roce-workload.md
@@ -2,20 +2,6 @@
 
 The RoCE workload image bundles all components needed for running distributed RCCL performance tests across AMD GPU clusters with AMD AINIC (Pollara) NICs.
 
-## Prerequisites
-
-- Kubernetes cluster with AMD GPU and AINIC (Pollara) NIC nodes
-- [AMD Network Operator](https://instinct.docs.amd.com/projects/network-operator/en/main/) deployed with a `NetworkConfig` CR
-- `amd-host-device-nad` [NetworkAttachmentDefinition](https://instinct.docs.amd.com/projects/network-operator/en/main/secondary_network/amd-host-device-cni.html) created
-- [AMD GPU Operator](https://instinct.docs.amd.com/projects/gpu-operator/en/latest/) deployed (for `amd.com/gpu` device resources)
-- [MPI Operator](https://github.com/kubeflow/mpi-operator) installed (for CVF and MPIJob-based workloads)
-
-**Important:** The workload image must be compatible with the AINIC driver version installed on the host nodes. The image bundles user-space AINIC libraries (libionic) that must match the host kernel driver. Use an image tagged with the same AINIC version as your deployed drivers (e.g., `ainic-1.117.5-a-77` in the image tag should match the firmware/driver version on the nodes).
-
-## Pre-built Images
-
-Pre-built images are available on [Docker Hub](https://hub.docker.com/r/rocm/roce-workload).
-
 ## What's Included
 
 | Component | Description |
@@ -28,12 +14,36 @@ Pre-built images are available on [Docker Hub](https://hub.docker.com/r/rocm/roc
 | OpenMPI | MPI implementation for multi-node communication |
 | AINIC drivers | User-space libraries for AMD AINIC (Pollara) NICs |
 
-## Quick Start
+## Getting the Image
+
+### Pre-built Images
+
+Pre-built images are available on [Docker Hub](https://hub.docker.com/r/rocm/roce-workload).
+
+**Important:** The workload image must be compatible with the AINIC driver version installed on the host nodes. The image bundles user-space AINIC libraries (libionic) that must match the host kernel driver. Use an image tagged with the same AINIC version as your deployed drivers (e.g., `ainic-1.117.5-a-77` in the image tag should match the firmware/driver version on the nodes).
+
+### Building a Custom Image
+
+To build a custom image with specific component versions, see the build instructions at [`docker/roce-workload/`](https://github.com/ROCm/network-operator/tree/main/docker/roce-workload).
+
+```bash
+cd docker/roce-workload
+./docker-build.sh <ainic_version>
+```
+
+## Using the Image
+
+The image can be used in two ways: **manually** for ad-hoc testing, or **with CVF** for automated fleet-wide validation.
+
+Both workflows require the cluster prerequisites described in the [Cluster Validation Framework requirements](README.md#requirements).
+
+### Manual Quick Start
 
 Deploy two workload pods and run an RCCL test to validate GPU-to-GPU communication over AINIC NICs:
 
+#### 1. Deploy workload pods
+
 ```bash
-# Deploy workload pods (adjust gpu/nic counts to match your hardware)
 kubectl apply -f - <<'EOF'
 apiVersion: v1
 kind: Pod
@@ -53,7 +63,7 @@ spec:
         add: [IPC_LOCK]
     resources:
       requests:
-        amd.com/gpu: 8
+        amd.com/gpu: 8   # adjust to match your hardware
         amd.com/nic: 2
       limits:
         amd.com/gpu: 8
@@ -106,23 +116,33 @@ spec:
       medium: Memory
       sizeLimit: 4Gi
 EOF
+```
 
-# Exchange SSH keys between pods
+Adjust `amd.com/gpu` and `amd.com/nic` counts to match your hardware. The anti-affinity rule ensures pods land on different nodes automatically.
+
+**For VMs with VNICs (SR-IOV VFs):** replace `amd.com/nic` with `amd.com/vnic` and `amd-host-device-nad` with `vf-amd-host-device-nad` in the pod spec above.
+
+#### 2. Exchange SSH keys
+
+```bash
 W0_KEY=$(kubectl exec rccl-worker-0 -- cat /root/.ssh/id_rsa.pub)
 W1_KEY=$(kubectl exec rccl-worker-1 -- cat /root/.ssh/id_rsa.pub)
 kubectl exec rccl-worker-0 -- bash -c "echo '$W1_KEY' >> /root/.ssh/authorized_keys"
 kubectl exec rccl-worker-1 -- bash -c "echo '$W0_KEY' >> /root/.ssh/authorized_keys"
+```
 
+#### 3. Run RCCL test
+
+```bash
 # Get pod IPs
 W0_IP=$(kubectl get pod rccl-worker-0 -o jsonpath='{.status.podIP}')
 W1_IP=$(kubectl get pod rccl-worker-1 -o jsonpath='{.status.podIP}')
 
-# Run RCCL test (set GPUS_PER_NODE to match amd.com/gpu above)
+# Run (GPUS_PER_NODE must match amd.com/gpu in the pod spec above)
 kubectl exec rccl-worker-0 -- env GPUS_PER_NODE=8 run_rccl.sh $W0_IP $W1_IP all_reduce_perf
-
-# Cleanup
-kubectl delete pod rccl-worker-0 rccl-worker-1
 ```
+
+Available collectives: `all_reduce_perf`, `broadcast_perf`, `reduce_scatter_perf`, `all_gather_perf`, `alltoall_perf`, `reduce_perf`, `scatter_perf`, `gather_perf`, `sendrecv_perf`
 
 A successful run ends with:
 
@@ -130,21 +150,18 @@ A successful run ends with:
 # Avg bus bandwidth    : 6.66557
 ```
 
-**For VMs with VNICs (SR-IOV VFs):** replace `amd.com/nic` with `amd.com/vnic` and `amd-host-device-nad` with `vf-amd-host-device-nad`.
+#### 4. Cleanup
 
-## Using with CVF
+```bash
+kubectl delete pod rccl-worker-0 rccl-worker-1
+```
 
-For fleet-wide cluster validation, use the [Cluster Validation Framework](cluster_validation_framework/README.md). Set the image in the CVF `config.yaml`:
+### Automated Validation with CVF
+
+For automated, fleet-wide cluster validation, use the [Cluster Validation Framework](README.md) instead of deploying pods manually. Set the image in the CVF `config.yaml`:
 
 ```yaml
 RCCL_WORKLOAD_IMAGE: "rocm/roce-workload:<tag>"
 ```
 
-## Building a Custom Image
-
-To build a custom image with specific component versions, see the build instructions at [`docker/roce-workload/`](https://github.com/ROCm/network-operator/tree/main/docker/roce-workload).
-
-```bash
-cd docker/roce-workload
-./docker-build.sh <ainic_version>
-```
+See the [CVF deployment steps](README.md#deployment-steps) for the full setup.

--- a/docs/installation/workload.md
+++ b/docs/installation/workload.md
@@ -25,7 +25,7 @@ This step defines a secondary network using a NetworkAttachmentDefinition, which
 
 ### 2. Deploy the Workload
 
-Pre-built workload images are available on [Docker Hub](https://hub.docker.com/r/rocm/roce-workload). To build a custom image, see [RoCE Workload Image](../roce-workload.md).
+Pre-built workload images are available on [Docker Hub](https://hub.docker.com/r/rocm/roce-workload). To build a custom image, see [RoCE Workload Image](../cluster_validation_framework/roce-workload.md).
 
 Create a workload requesting for a nic/vnic
 

--- a/docs/sphinx/_toc.yml.in
+++ b/docs/sphinx/_toc.yml.in
@@ -69,5 +69,5 @@ subtrees:
     entries:
       - file: cluster_validation_framework/README
         title: Cluster Validation and Job Scheduling
-      - file: roce-workload
+      - file: cluster_validation_framework/roce-workload
         title: RoCE Workload Image


### PR DESCRIPTION
## Summary

- Move `roce-workload.md` into `cluster_validation_framework/` to match its TOC section
- Consolidate prerequisites to CVF README as single source of truth
- Clear ownership: docs page owns usage/deployment, docker README owns building
- Fix heading hierarchy in CVF README for correct Sphinx rendering
- Update all cross-references and TOC for new file location

🤖 Generated with [Claude Code](https://claude.com/claude-code)